### PR TITLE
fix .zshrc location

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ brew cask install cakebrew
 brew install zsh
 ```
 
-Add this to my `./zshrc`
+Add this to my `~/.zshrc`
 
 ```sh
 export HOMEBREW_CASK_OPTS="--appdir=/Applications"


### PR DESCRIPTION
zshrc contains a . in the beginning.
Added also `~` to point user's home dir independent of it's location.